### PR TITLE
Docker Support

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:18.04
+LABEL maintainer="Aperture Development <webmaster@Aperture-Development.de>"
+ENV DEBIAN_FRONTEND noninteractive
+# Prepare Container Enviroment
+RUN useradd -ms /bin/bash gmodws &&\
+    dpkg --add-architecture i386 &&\
+    apt-get update &&\
+    apt-get -y --no-install-recommends install software-properties-common lib32gcc1 curl lib32stdc++6 ca-certificates libsdl2-2.0-0:i386 unzip &&\
+    add-apt-repository ppa:ubuntu-toolchain-r/test &&\
+    apt-get update &&\
+    apt-get -y install --reinstall lib32stdc++6 libstdc++6 &&\
+    apt-get clean autoclean &&\
+    apt-get autoremove -y &&\
+    rm -rf /var/lib/apt/lists/*
+# Copy shell script into container and make them runable
+COPY downloadLatest.sh /home/gmodws/downloadLatest.sh
+COPY wrapper.sh /wrapper.sh
+RUN chmod +x /home/gmodws/downloadLatest.sh &&\
+    chmod +x /wrapper.sh
+# Switch user and working directory
+USER gmodws
+WORKDIR /home/gmodws
+# Prepare folders and download SteamCMD
+RUN mkdir -p ~/upload &&\
+    mkdir ~/Steam &&\ 
+    cd ~/Steam &&\
+    curl -sqL "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" | tar zxvf -
+# Download the latest gmodws release, unzip it and make it runable
+RUN bash ~/downloadLatest.sh ~/gmodws/gmodws.zip &&\
+    cd ~/gmodws &&\
+    unzip gmodws.zip &&\
+    chmod +x gmodws steamclient.so
+# Set wrapper as entrypoint
+ENTRYPOINT ["/wrapper.sh"]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -21,8 +21,7 @@ RUN chmod +x /home/gmodws/downloadLatest.sh &&\
 USER gmodws
 WORKDIR /home/gmodws
 # Prepare folders and download SteamCMD
-RUN mkdir -p ~/upload &&\
-    mkdir ~/Steam &&\ 
+RUN mkdir ~/upload ~/gmodws ~/Steam &&\ 
     cd ~/Steam &&\
     curl -sqL "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" | tar zxvf -
 # Download the latest gmodws release, unzip it and make it runable

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,12 +1,12 @@
 # Docker Instructions
 
 ## Manually building the container
-First ``cd`` into the Docker directory of this repository and thenrun this command:
+First ``cd`` into the Docker directory of this repository and then run this command:
 ```
 docker build . -t gmodws:latest
 ```
 
-The building process will take some time, but in the end you can just use ``gmodws:latest`` as your ``<IMAGE>`` variable in the usage instructi9ons
+The building process will take some time, but in the end you can just use ``gmodws:latest`` as your ``<IMAGE>`` variable in the usage instructions
 
 ## Using the hosted container
 Aperture Development provides a hosted GModWS container on the DockerHub at this repository: https://hub.docker.com/repository/docker/aperturedevelopment/gmodws

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,27 @@
+# Docker Instructions
+
+## Manually building the container
+First ``cd`` into the Docker directory of this repository and thenrun this command:
+```
+docker build . -t gmodws:latest
+```
+
+The building process will take some time, but in the end you can just use ``gmodws:latest`` as your ``<IMAGE>`` variable in the usage instructi9ons
+
+## Using the hosted container
+Aperture Development provides a hosted GModWS container on the DockerHub at this repository: https://hub.docker.com/repository/docker/aperturedevelopment/gmodws
+That container will get constantly updated, and to use it you only have to use ``aperturedevelopment/gmodws:latest`` as your ``<IMAGE>`` variable in the usage instructions.
+
+
+## How to use the docker container
+```
+docker volume create gmodws_steam
+docker run --rm -it -e STEAM_USER=<STEAM LOGIN NAME> -v gmodws_steam:/home/gmodws/Steam <IMAGE> login
+```
+
+Now you can easily update your addon using this command:
+```
+docker run --rm -it -e STEAM_USER=<STEAM LOGIN NAME> -v gmodws_steam:/home/gmodws/Steam -v <DIRECTORY_OF_GMA>:/home/gmodws/upload <IMAGE> upload <Workshop id> <GMA Filename> <Changelog>
+```
+
+If the login cache expired you will see a error message saying ``[ERROR] Not logged in or cached data expired, please login`` to fix that you only have to login again.

--- a/Docker/downloadLatest.sh
+++ b/Docker/downloadLatest.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+GMODWS_LATEST=$(curl --silent "https://api.github.com/repos/Meachamp/gmodws/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
+GMODWS_ZIP=$(echo "https://github.com/Meachamp/gmodws/releases/download/$GMODWS_LATEST/gmodws.zip")
+curl -sqL $GMODWS_ZIP -o $1
+exit 0

--- a/Docker/wrapper.sh
+++ b/Docker/wrapper.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+ARGUMENT=${1,,}
+
+if [ "$ARGUMENT" == "login" ]; then
+    ~/Steam/steamcmd.sh +login $STEAM_USER +quit
+    exit 0
+elif [ "$ARGUMENT" == "upload" ]; then
+    ~/Steam/steamcmd.sh +login $STEAM_USER +quit > /home/gmodws/steamcmd.log&
+    sleep 5s
+    LOGGED_IN=$(grep -o 'Logged in OK' /home/gmodws/steamcmd.log)
+
+    if [ "$LOGGED_IN" == "Logged in OK" ]; then
+        cd ~/gmodws
+        ./gmodws $STEAM_USER $2 ~/upload/$3 "${@:4}" 
+        exit 0
+    else
+        echo "[ERROR] Not logged in or cached data expired, please login"
+        exit 1
+    fi
+else
+    echo "[ERROR] No argument supplied"
+    exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -26,18 +26,9 @@ Optionally, you can specify a fourth argument to the command. This will all you 
 For certain CI configurations where a new environment is setup each time a build is triggered, SteamCMD may be too much trouble. Instead, you can log in to your steam account without cached credentials and without steamCMD by setting the `STEAM_PASSWORD` environment variable. Please note that this requires steamguard to be disabled. If you go this route, you should have a dedicated account for pushing workshop builds. 
 
 # Using Docker
-[Docker](https://docs.docker.com/get-docker/) is a great solution for distributing software, mainly because the enviroment required to run the software gets shipped with it. That means all dependencies are already present and you only need to run the software. Preparing the GModWS container is fairly easy, just run the following commands:
-```
-docker volume create gmodws_steam
-docker run --rm -it -e STEAM_USER=<STEAM LOGIN NAME> -v gmodws_steam:/home/gmodws/Steam aperturedevelopment/gmodws:latest login
-```
+[Docker](https://docs.docker.com/get-docker/) is a great solution for distributing software, mainly because the enviroment required to run the software gets shipped with it. That means all dependencies are already present and you only need to run the software. There are two ways of using the GModWS container, the first being to manually build the container and the second yould be to use the hosted solution.
 
-Now you can easily update your addon using this command:
-```
-docker run --rm -it -e STEAM_USER=<STEAM LOGIN NAME> -v gmodws_steam:/home/gmodws/Steam -v <DIRECTORY_OF_GMA>:/home/gmodws/upload aperturedevelopment/gmodws:latest upload <Workshop id> <GMA Filename> <Changelog>
-```
-
-If the login cache expired you will see a error message saying ``[ERROR] Not logged in or cached data expired, please login`` to fix that you only have to login again.
+You can find the Dockerfile and instructions inside the [Docker folder](/Docker)
 
 # Debugging
 Setting the `GMODWS_DEBUG` environment variable will cause gmodws to enter verbose mode, which may be helpful for debugging. 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Optionally, you can specify a fourth argument to the command. This will all you 
 For certain CI configurations where a new environment is setup each time a build is triggered, SteamCMD may be too much trouble. Instead, you can log in to your steam account without cached credentials and without steamCMD by setting the `STEAM_PASSWORD` environment variable. Please note that this requires steamguard to be disabled. If you go this route, you should have a dedicated account for pushing workshop builds. 
 
 # Using Docker
-[Docker](https://docs.docker.com/get-docker/) is a great solution for distributing software, mainly because the enviroment required to run the software gets shipped with it. That means all dependencies are already present and you only need to run the software. There are two ways of using the GModWS container, the first being to manually build the container and the second yould be to use the hosted solution.
+[Docker](https://docs.docker.com/get-docker/) is a great solution for distributing software, mainly because the enviroment required to run the software gets shipped with it. That means all dependencies are already present and you only need to run the software. There are two ways of using the GModWS container, the first being to manually build the container and the second would be to use the hosted solution.
 
 You can find the Dockerfile and instructions inside the [Docker folder](/Docker)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ Optionally, you can specify a fourth argument to the command. This will all you 
 # Without SteamCMD
 For certain CI configurations where a new environment is setup each time a build is triggered, SteamCMD may be too much trouble. Instead, you can log in to your steam account without cached credentials and without steamCMD by setting the `STEAM_PASSWORD` environment variable. Please note that this requires steamguard to be disabled. If you go this route, you should have a dedicated account for pushing workshop builds. 
 
+# Using Docker
+[Docker](https://docs.docker.com/get-docker/) is a great solution for distributing software, mainly because the enviroment required to run the software gets shipped with it. That means all dependencies are already present and you only need to run the software. Preparing the GModWS container is fairly easy, just run the following commands:
+```
+docker volume create gmodws_steam
+docker run --rm -it -e STEAM_USER=<STEAM LOGIN NAME> -v gmodws_steam:/home/gmodws/Steam aperturedevelopment/gmodws:latest login
+```
+
+Now you can easily update your addon using this command:
+```
+docker run --rm -it -e STEAM_USER=<STEAM LOGIN NAME> -v gmodws_steam:/home/gmodws/Steam -v <DIRECTORY_OF_GMA>:/home/gmodws/upload aperturedevelopment/gmodws:latest upload <Workshop id> <GMA Filename> <Changelog>
+```
+
+If the login cache expired you will see a error message saying ``[ERROR] Not logged in or cached data expired, please login`` to fix that you only have to login again.
+
 # Debugging
 Setting the `GMODWS_DEBUG` environment variable will cause gmodws to enter verbose mode, which may be helpful for debugging. 
 


### PR DESCRIPTION
This PR includes a Dockerfile for a GModWS image. Serving GModWS using docker allows people to be 100% able to use it, since the enviroment required for running it is served with the software. 

I am also going to setup a my CI to build new container versions and push them to https://hub.docker.com/repository/docker/aperturedevelopment/gmodws as soon as you make updates to GModWS. I could also change the dockerfile to not use the latest release version but instead build GModWS inside the container too if that would be preffered